### PR TITLE
Use smart constructor

### DIFF
--- a/src/test/scala/nl/gn0s1s/between/AxiomSpec.scala
+++ b/src/test/scala/nl/gn0s1s/between/AxiomSpec.scala
@@ -16,10 +16,10 @@ object AxiomSpec extends Properties("Axiom") {
     s <- Gen.choose(q, Instant.MAX) if q < s
     t <- Gen.choose(Instant.MIN, q) if t < q
   } yield (
-    Interval[Instant](p, q), // i
-    Interval[Instant](q, r), // j
-    Interval[Instant](q, s), // k
-    Interval[Instant](t, q) // l
+    Interval[Instant](p, q).get, // i
+    Interval[Instant](q, r).get, // j
+    Interval[Instant](q, s).get, // k
+    Interval[Instant](t, q).get // l
   )
 
   property("M1: if two periods both meet a third, then any period met by one must also be met by the other.") =
@@ -35,10 +35,10 @@ object AxiomSpec extends Properties("Axiom") {
     t <- Gen.choose(s, Instant.MAX) if s < t
     u <- Gen.choose(t, Instant.MAX) if t < u
   } yield (
-    Interval[Instant](p, q), // i
-    Interval[Instant](q, r), // j
-    Interval[Instant](s, t), // k
-    Interval[Instant](t, u) // l
+    Interval[Instant](p, q).get, // i
+    Interval[Instant](q, r).get, // j
+    Interval[Instant](s, t).get, // k
+    Interval[Instant](t, u).get // l
   )
 
   property(
@@ -56,7 +56,7 @@ object AxiomSpec extends Properties("Axiom") {
   def genML1 = for {
     p <- Gen.choose(Instant.MIN, Instant.MAX)
     q <- Gen.choose(p, Instant.MAX) if p < q
-  } yield Interval[Instant](p, q) // i
+  } yield Interval[Instant](p, q).get // i
 
   property("ML1: an interval cannot meet itself") = forAll(genML1) { i =>
     !i.meets(i)
@@ -67,8 +67,8 @@ object AxiomSpec extends Properties("Axiom") {
     q <- Gen.choose(p, Instant.MAX) if p < q
     r <- Gen.choose(q, Instant.MAX) if q < r
   } yield (
-    Interval[Instant](p, q), // i
-    Interval[Instant](q, r) // j
+    Interval[Instant](p, q).get, // i
+    Interval[Instant](q, r).get // j
   )
 
   property("ML2: if i meets j then j does not meet i") = forAll(genML2) { case (i, j) =>
@@ -80,8 +80,8 @@ object AxiomSpec extends Properties("Axiom") {
     q <- Gen.choose(p, Instant.MAX) if p < q
     r <- Gen.choose(q, Instant.MAX) if q < r
   } yield (
-    Interval[Instant](p, q), // i
-    Interval[Instant](q, r) // m
+    Interval[Instant](p, q).get, // i
+    Interval[Instant](q, r).get // m
   )
 
   property("ML3: there is no period m such that i:m:i,") = forAll(genML3) { case (i, m) =>
@@ -94,14 +94,14 @@ object AxiomSpec extends Properties("Axiom") {
     r <- Gen.choose(Instant.MIN, p) if r < p
     s <- Gen.choose(q, Instant.MAX) if q < s
   } yield (
-    Interval[Instant](p, q), // i
+    Interval[Instant](p, q).get, // i
     r, // startOfJ
     s // endOfK
   )
 
   property("M3: time does not start or stop") = forAll(genM3) { case (i, startOfJ, endOfK) =>
-    val j = Interval(startOfJ, i.`-`)
-    val k = Interval(i.`+`, endOfK)
+    val j = Interval(startOfJ, i.`-`).get
+    val k = Interval(i.`+`, endOfK).get
     j.meets(i) && i.meets(k)
   }
 
@@ -112,17 +112,17 @@ object AxiomSpec extends Properties("Axiom") {
     s <- Gen.choose(Instant.MIN, p) if s < p
     t <- Gen.choose(r, Instant.MAX) if r < t
   } yield (
-    Interval[Instant](p, q), // i
-    Interval[Instant](q, r), // j
+    Interval[Instant](p, q).get, // i
+    Interval[Instant](q, r).get, // j
     s, // startOfM
     t // endOfN
   )
 
   property("M4: if two meets are separated by intervals, then this sequence is a longer interval") = forAll(genM4) {
     case (i, j, startOfM, endOfN) =>
-      val m = Interval(startOfM, i.`-`)
-      val n = Interval(j.`+`, endOfN)
-      val k = Interval(m.`+`, n.`-`)
+      val m = Interval(startOfM, i.`-`).get
+      val n = Interval(j.`+`, endOfN).get
+      val k = Interval(m.`+`, n.`-`).get
       (m.meets(i) && i.meets(j) && j.meets(n)) &&
       (m.meets(k) && k.meets(n))
   }
@@ -133,10 +133,10 @@ object AxiomSpec extends Properties("Axiom") {
     r <- Gen.choose(q, Instant.MAX) if q < r
     s <- Gen.choose(r, Instant.MAX) if r < s
   } yield (
-    Interval[Instant](p, q), // i
-    Interval[Instant](q, r), // j
-    Interval[Instant](r, s), // l
-    Interval[Instant](q, s) // k
+    Interval[Instant](p, q).get, // i
+    Interval[Instant](q, r).get, // j
+    Interval[Instant](r, s).get, // l
+    Interval[Instant](q, s).get // k
   )
 
   property("M5: There is only one time period between any two meeting-places.") = forAll(genM5) { case (i, j, l, k) =>
@@ -145,8 +145,8 @@ object AxiomSpec extends Properties("Axiom") {
   }
 
   property("M4.1: i:j implies m:i+j:n") = forAll(genM4) { case (i, j, startOfM, endOfN) =>
-    val m = Interval(startOfM, i.`-`)
-    val n = Interval(j.`+`, endOfN)
+    val m = Interval(startOfM, i.`-`).get
+    val n = Interval(j.`+`, endOfN).get
     val ij = i.union(j).get
     (m.meets(i) && i.meets(j) && j.meets(n)) &&
     (m.meets(ij) && ij.meets(n))


### PR DESCRIPTION
Applying this PR will switch the existing constructor to a smart constructor. This gets rid of the `require`, which can throw exceptions. Using a smart constructor creating an `Interval` returns an `Option`. This makes handling an unsuccessful creation very explicit.